### PR TITLE
Remove webpack/sjs bundler from jsdocs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,24 +135,14 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
 lazy val jsdocs = project
   .in(file("jsdocs"))
   .settings(
-    //scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
-    webpackBundlingMode := BundlingMode.LibraryOnly(),
-    scalaJSUseMainModuleInitializer := true,
     libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.4.0",
     libraryDependencies += ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13),
     libraryDependencies += ("org.scala-js" %%% "scalajs-java-time" % "1.0.0").cross(CrossVersion.for3Use2_13),
-    scalaJSLinkerConfig ~= (_.withSourceMap(false)),
-    Compile / npmDependencies ++= Seq(
-      "vega-typings" -> "0.22.3",
-      "vega-embed" -> "6.21.3",
-      "vega" -> "5.22.1",
-      "vega-lite" -> "5.6.1"
-    )
+    scalaJSLinkerConfig ~= (_.withSourceMap(false))
   )
   .dependsOn(core.js)
   .enablePlugins(ScalaJSPlugin)
   .enablePlugins(NoPublishPlugin)
-  .enablePlugins(ScalaJSBundlerPlugin)
 
 lazy val unidocs = project
   .in(file("unidocs"))
@@ -166,8 +156,6 @@ lazy val docs = project
   .in(file("myproject-docs")) // important: it must not be docs/
   .settings(
     mdocJS := Some(jsdocs),
-    //mdocJSLibraries := webpack.in(jsdocs, Compile, fullOptJS).value,
-    mdocJSLibraries := (jsdocs / Compile / fullOptJS / webpack).value,
     //mdocOut := new File("docs"),
     dependencyOverrides += "com.lihaoyi" %% "upickle" % "3.0.0-M2",
     dependencyOverrides += "com.lihaoyi" %% "geny" % "1.0.0",

--- a/core/js/src/main/scala/viz/vega/facades/VegaEmbed.scala
+++ b/core/js/src/main/scala/viz/vega/facades/VegaEmbed.scala
@@ -83,5 +83,5 @@ trait EmbedOptions:
 object VegaEmbed:
 
   @js.native
-  @JSImport("vega-embed", JSImport.Default)
+  @JSImport("vega-embed", JSImport.Default, "vegaEmbed")
   def embed(clz: String, spec: js.Dynamic, opts: EmbedOptions): js.Promise[js.Dynamic] = js.native

--- a/core/js/src/main/scala/viz/vega/facades/VegaView.scala
+++ b/core/js/src/main/scala/viz/vega/facades/VegaView.scala
@@ -21,7 +21,7 @@ import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.JSON
 
 @js.native
-@JSImport("vega-view", JSImport.Namespace)
+@JSImport("vega-view", JSImport.Namespace, "vega.View")
 class VegaView(parsedSpec: js.Dynamic, config: js.Dynamic) extends js.Object:
 
   def runAsync(): Unit = js.native

--- a/raw_docs/default.template.html
+++ b/raw_docs/default.template.html
@@ -22,6 +22,9 @@
     @:linkJS { paths = ${helium.site.includeJS} }
     @:heliumInitVersions
     @:heliumInitPreview(container)
+    <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
     <script> /* for avoiding page load transitions */ </script>
   </head>
 


### PR DESCRIPTION
Might need some tweaking but at a glance seems to work.